### PR TITLE
헤더에 해시태그 메뉴 추가하기

### DIFF
--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}"/>
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}"/>
+</thlogic>


### PR DESCRIPTION
이전까지는 해시태그 검색 페이지에 들어갈 방법이 URL로 직접 접근하는 방법 밖에 없었다. 쉽게 들어갈 수 있도록 헤더에 링크 연결.